### PR TITLE
Allow memoization patterns in 'initialize' methods

### DIFF
--- a/lib/rubocop/cop/betterment/memoization_with_arguments.rb
+++ b/lib/rubocop/cop/betterment/memoization_with_arguments.rb
@@ -21,7 +21,7 @@ module RuboCop
 
         def on_def(node)
           (method_name, ivar_assign) = memoized?(node)
-          return if ivar_assign.nil? || node.arguments.length.zero?
+          return if ivar_assign.nil? || node.arguments.length.zero? || method_name == :initialize
 
           msg = format(MSG, method: method_name)
           add_offense(node, location: ivar_assign.source_range, message: msg)

--- a/spec/rubocop/cop/betterment/memoization_with_arguments_spec.rb
+++ b/spec/rubocop/cop/betterment/memoization_with_arguments_spec.rb
@@ -246,4 +246,13 @@ describe RuboCop::Cop::Betterment::MemoizationWithArguments, :config do
       end
     end
   end
+
+  context 'for initialize methods' do
+    let(:method_arguments) { '(arguments = {})' }
+    let(:method_name) { 'initialize' }
+
+    it 'does not register an offense' do
+      expect_no_offenses(method_def)
+    end
+  end
 end


### PR DESCRIPTION
/domain @effron
/platform @smudge 

Sometimes default values are set in the 'initialize' method via `@foo ||= true`, and in this case there isn't a concern for stale ivar values considering that 'initialize' is only run once per instance. So this change adds an exception for `initialize` methods to the rule.

For example, with ActiveModel we might do something like:

```ruby
class Person
  include ActiveModel::Model
  attr_accessor :id, :name, :omg

  def initialize(attributes = {})
    super
    @omg ||= true
  end
end
```
([example from the Rails docs](https://api.rubyonrails.org/classes/ActiveModel/Model.html))