### PR TITLE
Fix false positives from ActiveJobPerformable

### DIFF
--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.2.0"
+  s.version = "1.2.1"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/lib/rubocop/cop/betterment/active_job_performable.rb
+++ b/lib/rubocop/cop/betterment/active_job_performable.rb
@@ -26,7 +26,7 @@ module RuboCop
           return unless has_perform_method?(node)
           return if subclasses_application_job?(node)
 
-          add_offense(node.children.first)
+          add_offense(node.identifier)
         end
 
         private

--- a/lib/rubocop/cop/betterment/active_job_performable.rb
+++ b/lib/rubocop/cop/betterment/active_job_performable.rb
@@ -32,7 +32,15 @@ module RuboCop
         private
 
         def has_perform_method?(node)
-          is_perform_method?(node.body)
+          possible_methods_within(node).any? { |n| is_perform_method?(n) }
+        end
+
+        def possible_methods_within(node)
+          if node.body.begin_type?
+            node.body.children
+          else
+            [node.body]
+          end
         end
       end
     end

--- a/lib/rubocop/cop/betterment/active_job_performable.rb
+++ b/lib/rubocop/cop/betterment/active_job_performable.rb
@@ -2,7 +2,7 @@ module RuboCop
   module Cop
     module Betterment
       class ActiveJobPerformable < Cop
-        MSG = <<-DOC.freeze
+        MSG = <<~DOC.freeze
           Classes that are "performable" should be ActiveJobs
 
           class MyJob < ApplicationJob

--- a/lib/rubocop/cop/betterment/active_job_performable.rb
+++ b/lib/rubocop/cop/betterment/active_job_performable.rb
@@ -23,8 +23,8 @@ module RuboCop
         PATTERN
 
         def on_class(node)
-          return unless has_perform_method?(node)
           return if subclasses_application_job?(node)
+          return unless has_perform_method?(node)
 
           add_offense(node.identifier)
         end

--- a/lib/rubocop/cop/betterment/active_job_performable.rb
+++ b/lib/rubocop/cop/betterment/active_job_performable.rb
@@ -32,7 +32,7 @@ module RuboCop
         private
 
         def has_perform_method?(node)
-          node.descendants.find { |n| is_perform_method?(n) }
+          is_perform_method?(node.body)
         end
       end
     end

--- a/spec/rubocop/cop/betterment/active_job_performable_spec.rb
+++ b/spec/rubocop/cop/betterment/active_job_performable_spec.rb
@@ -30,37 +30,32 @@ describe RuboCop::Cop::Betterment::ActiveJobPerformable, :config do
   end
 
   it 'accepts a performable that subclasses ApplicationJob' do
-    inspect_source(<<~RUBY)
+    expect_no_offenses(<<~RUBY)
       class MyJob < ApplicationJob
         def perform
           MyModel.new.save!
         end
       end
     RUBY
-
-    expect(cop.offenses.size).to be(0)
   end
 
   it 'accepts a performable that subclasses Module::ApplicationJob' do
-    inspect_source(<<~RUBY)
+    expect_no_offenses(<<~RUBY)
       class MyJob < MyModule::ApplicationJob
         def perform
           MyModel.new.save!
         end
       end
     RUBY
-
-    expect(cop.offenses.size).to be(0)
   end
 
   it 'accepts a class that does not define "perform"' do
-    inspect_source(<<~RUBY)
+    expect_no_offenses(<<~RUBY)
       class MyModel
         def create
           Model.create! params[:user_id]
         end
       end
     RUBY
-    expect(cop.offenses.size).to be(0)
   end
 end

--- a/spec/rubocop/cop/betterment/active_job_performable_spec.rb
+++ b/spec/rubocop/cop/betterment/active_job_performable_spec.rb
@@ -58,4 +58,16 @@ describe RuboCop::Cop::Betterment::ActiveJobPerformable, :config do
       end
     RUBY
   end
+
+  it 'accepts a class that includes a job' do
+    expect_no_offenses(<<~RUBY)
+      class MyBusinessLogic
+        class MyJob < ApplicationJob
+          def perform
+            MyBusinessLogic.call
+          end
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/betterment/active_job_performable_spec.rb
+++ b/spec/rubocop/cop/betterment/active_job_performable_spec.rb
@@ -29,6 +29,26 @@ describe RuboCop::Cop::Betterment::ActiveJobPerformable, :config do
     expect(cop.offenses.first.message).to include('Classes that are "performable" should be ActiveJobs')
   end
 
+  it 'rejects a performable that has multiple methods' do
+    inspect_source(<<~RUBY)
+      class MyJob
+        def foo
+        end
+
+        def perform
+          MyModel.new.save!
+        end
+
+        def bar
+        end
+      end
+    RUBY
+
+    expect(cop.offenses.size).to be(1)
+    expect(cop.offenses.map(&:line)).to eq([1])
+    expect(cop.offenses.first.message).to include('Classes that are "performable" should be ActiveJobs')
+  end
+
   it 'accepts a performable that subclasses ApplicationJob' do
     expect_no_offenses(<<~RUBY)
       class MyJob < ApplicationJob

--- a/spec/rubocop/cop/betterment/active_job_performable_spec.rb
+++ b/spec/rubocop/cop/betterment/active_job_performable_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::ActiveJobPerformable, :config do
   it 'rejects a performable that is a plain ruby class' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyJob
         def perform
           MyModel.new.save!
         end
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to be(1)
     expect(cop.offenses.map(&:line)).to eq([1])
@@ -16,13 +16,13 @@ describe RuboCop::Cop::Betterment::ActiveJobPerformable, :config do
   end
 
   it 'rejects a performable that does not subclass ApplicationJob' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyJob < Base::Class
         def perform
           MyModel.new.save!
         end
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to be(1)
     expect(cop.offenses.map(&:line)).to eq([1])
@@ -30,37 +30,37 @@ describe RuboCop::Cop::Betterment::ActiveJobPerformable, :config do
   end
 
   it 'accepts a performable that subclasses ApplicationJob' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyJob < ApplicationJob
         def perform
           MyModel.new.save!
         end
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to be(0)
   end
 
   it 'accepts a performable that subclasses Module::ApplicationJob' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyJob < MyModule::ApplicationJob
         def perform
           MyModel.new.save!
         end
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to be(0)
   end
 
   it 'accepts a class that does not define "perform"' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyModel
         def create
           Model.create! params[:user_id]
         end
       end
-    DEF
+    RUBY
     expect(cop.offenses.size).to be(0)
   end
 end

--- a/spec/rubocop/cop/betterment/allowlist_blocklist_spec.rb
+++ b/spec/rubocop/cop/betterment/allowlist_blocklist_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::AllowlistBlocklist, :config do
   it 'rejects a method that should use allowlist' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyClass
         def whitelist; end
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line)).to eq([1])
@@ -16,11 +16,11 @@ describe RuboCop::Cop::Betterment::AllowlistBlocklist, :config do
   end
 
   it 'rejects a class that should use allowlist' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class Whitelist;
         def method; end
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line)).to eq([1])
@@ -30,11 +30,11 @@ describe RuboCop::Cop::Betterment::AllowlistBlocklist, :config do
   end
 
   it 'rejects a variable that should use allowlist' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyClass;
         whitelist = 'something'
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line)).to eq([1])
@@ -44,11 +44,11 @@ describe RuboCop::Cop::Betterment::AllowlistBlocklist, :config do
   end
 
   it 'rejects a string that should use allowlist' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyClass;
         myvar = 'whitelist'
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line)).to eq([1])
@@ -58,11 +58,11 @@ describe RuboCop::Cop::Betterment::AllowlistBlocklist, :config do
   end
 
   it 'rejects a method that should use blocklist' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyClass
         def blacklist; end
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line)).to eq([1])
@@ -72,11 +72,11 @@ describe RuboCop::Cop::Betterment::AllowlistBlocklist, :config do
   end
 
   it 'rejects a class that should use blocklist' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class Blacklist
         def method; end
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line)).to eq([1])
@@ -86,11 +86,11 @@ describe RuboCop::Cop::Betterment::AllowlistBlocklist, :config do
   end
 
   it 'rejects a variable that should use blocklist' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyClass;
         blacklist = 'something else'
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line)).to eq([1])
@@ -100,11 +100,11 @@ describe RuboCop::Cop::Betterment::AllowlistBlocklist, :config do
   end
 
   it 'rejects a string that should use blocklist' do
-    inspect_source(<<-DEF)
+    inspect_source(<<~RUBY)
       class MyClass;
         myvar = 'blacklist'
       end
-    DEF
+    RUBY
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line)).to eq([1])

--- a/spec/rubocop/cop/betterment/authorization_in_controller_spec.rb
+++ b/spec/rubocop/cop/betterment/authorization_in_controller_spec.rb
@@ -23,14 +23,14 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
 
   context 'when creating or updating a model' do
     it 'registers an offense for unsafe parameters' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create
             Model.new params[:user_id]
             Model.create! params[:user_id]
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(2)
       expect(cop.offenses.map(&:line)).to eq([3, 4])
@@ -39,14 +39,14 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense for unsafe parameters retrieved via static strings' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create
             Model.new params['user_id']
             Model.create! params['user_id']
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(2)
       expect(cop.offenses.map(&:line)).to eq([3, 4])
@@ -55,7 +55,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense for selecting an unsafe parameter from a variable' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create
             dangerous_parameters = params.permit(:user_id)
@@ -63,7 +63,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.create! dangerous_parameters[:user_id]
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(2)
       expect(cop.offenses.map(&:line)).to eq([4, 5])
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense for variables holding unsafe parameters' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create
             dangerous_parameters = params.permit(:user_id)
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes dangerous_parameters
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(4)
       expect(cop.offenses.map(&:line)).to eq([4, 5, 6, 7])
@@ -91,7 +91,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense for methods returning unsafe parameters via static strings' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def dangerous_parameters
             params.permit('user_id')
@@ -104,7 +104,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes dangerous_parameters
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(4)
       expect(cop.offenses.map(&:line)).to eq([7, 8, 9, 10])
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense for methods returning unsafe parameters' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def dangerous_parameters
             params.permit(:user_id)
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes dangerous_parameters
           end
         end
-      DEF
+      RUBY
       expect(cop.offenses.size).to be(4)
       expect(cop.offenses.map(&:line)).to eq([7, 8, 9, 10])
       expect(cop.highlights.uniq).to eq(['dangerous_parameters'])
@@ -134,7 +134,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense for methods returning unsafe parameters via kwargs' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def dangerous_parameters
             params.permit(accounts: :user_id)
@@ -147,7 +147,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes dangerous_parameters
           end
         end
-      DEF
+      RUBY
       expect(cop.offenses.size).to be(4)
       expect(cop.offenses.map(&:line)).to eq([7, 8, 9, 10])
       expect(cop.highlights.uniq).to eq(['dangerous_parameters'])
@@ -155,7 +155,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense when selecting an unsafe parameter from a method' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def variety_params
             params.permit(:safe, :also_safe, :user_id)
@@ -168,7 +168,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes variety_params[:user_id]
           end
         end
-      DEF
+      RUBY
       expect(cop.offenses.size).to be(4)
       expect(cop.offenses.map(&:line)).to eq([7, 8, 9, 10])
       expect(cop.highlights.uniq).to eq(['variety_params[:user_id]'])
@@ -176,7 +176,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense when a model is created or updated using a method that returns an extracted parameter' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def user_id
             params[:user_id]
@@ -189,7 +189,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes(user_id: user_id)
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(4)
       expect(cop.offenses.map(&:line)).to eq([7, 8, 9, 10])
@@ -198,7 +198,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense when passing an unsafe parameter into a keyword arg' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create_params
             params.permit(:user_id, :username)
@@ -209,7 +209,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.create!(parameters: create_params)
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(2)
       expect(cop.offenses.map(&:line)).to eq([7, 8])
@@ -218,7 +218,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense when dangerous parameters are stored and used' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create_params
             params.permit(:user_id, :username)
@@ -229,7 +229,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.new(user_id: @temporary_parameters)
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(1)
       expect(cop.offenses.map(&:line)).to eq([8])
@@ -238,7 +238,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense when a method returning unsafe parameters is stored, modified, and used' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create_params
             params.permit(:user_id, :username)
@@ -255,7 +255,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.new(parameters: @some_more_params.merge(key: value))
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(5)
       expect(cop.offenses.map(&:line)).to eq([8, 9, 10, 11, 14])
@@ -264,7 +264,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'registers an offense when a method returning unsafe parameters is stored and used' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create_params
             params.permit(:user_id, :username)
@@ -278,7 +278,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes @temporary_parameters
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(4)
       expect(cop.offenses.map(&:line)).to eq([8, 9, 10, 11])
@@ -287,7 +287,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'does not register an offense when selecting a safe parameter from a variable' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def a_variety_of_parameters
             params.permit(:safe, :also_safe, :user_id)
@@ -301,11 +301,11 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes(safe_parameter: @test[:safe])
           end
         end
-      DEF
+      RUBY
     end
 
     it 'does not register an offense when selecting a safe parameter from a method' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def a_variety_of_parameters
             params.permit(:safe, :also_safe, :user_id)
@@ -316,11 +316,11 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.create! a_variety_of_parameters[:safe]
           end
         end
-      DEF
+      RUBY
     end
 
     it 'does not register an offense when the parameters are unknown' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create
             Model.new(config_params: params)
@@ -329,11 +329,11 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes(config_params: params)
           end
         end
-      DEF
+      RUBY
     end
 
     it 'does not register an offense when a method permits and indexes using a non-symbol key' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create
             Model.new(test: something_unexpected)
@@ -343,11 +343,11 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             params[something.unexpected]
           end
         end
-      DEF
+      RUBY
     end
 
     it 'does not register an offense when a method wraps unexpected types' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create_params
             if test
@@ -361,11 +361,11 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.new(create_params)
           end
         end
-      DEF
+      RUBY
     end
 
     it 'does not register an offense when another method wraps an unsafe parameter' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create_params
             params.permit(:safe, :also_safe, :user_id)
@@ -375,11 +375,11 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.new(current_user.users.find(create_params[:user_id]))
           end
         end
-      DEF
+      RUBY
     end
 
     it 'does not register an offense when storing and using a safe parameter' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create
             @safe_parameter = params[:safe_name]
@@ -389,11 +389,11 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes(name: @safe_parameter)
           end
         end
-      DEF
+      RUBY
     end
 
     it 'does not register an offense when extracting an unsafe parameter from an unknown source' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create
             Model.new unknown_source[:user_id]
@@ -402,11 +402,11 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             @model.assign_attributes unknown_source[:user_id]
           end
         end
-      DEF
+      RUBY
     end
 
     it 'registers an offense when a method permits and indexes using an unsafe parameter' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def index
             presenter = Some::Presenter.new(
@@ -419,7 +419,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             params.permit(:account_id)[:account_id]
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(1)
       expect(cop.offenses.map(&:line)).to eq([5])
@@ -428,7 +428,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     end
 
     it 'does not register an offense when parameters are used safely before return' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def user_id
             account_id = params.permit(:user_id)
@@ -442,13 +442,13 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.new(parameters: user_id)
           end
         end
-      DEF
+      RUBY
     end
 
     it 'allows unsafe parameters to be specified via config' do
       temp = cop.unsafe_parameters
       cop.unsafe_parameters = %i(dangerous shady)
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def dangerous_param
             params.permit(:shady, :benign)
@@ -463,7 +463,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.new params[:user_id]
           end
         end
-      DEF
+      RUBY
       cop.unsafe_parameters = temp
 
       expect(cop.offenses.size).to be(3)
@@ -475,7 +475,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
     it 'allows the config to specify a regex alternative to _id' do
       temp = cop.unsafe_regex
       cop.unsafe_regex = /(.*_fk$|^id_.*$)/
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def user
             params.permit(:user_fk)
@@ -491,7 +491,7 @@ describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
             Model.new params[:user_id]
           end
         end
-      DEF
+      RUBY
       cop.unsafe_regex = temp
 
       expect(cop.offenses.size).to be(3)

--- a/spec/rubocop/cop/betterment/dynamic_params_spec.rb
+++ b/spec/rubocop/cop/betterment/dynamic_params_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Betterment::DynamicParams, :config do
 
   context 'when creating or updating a model' do
     it 'registers an offense when parameter names are accessed dynamically' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create
             dynamic_field = :user_id
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Betterment::DynamicParams, :config do
             params[dynamic_field]
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(3)
       expect(cop.offenses.map(&:line)).to eq([4, 5, 6])
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Betterment::DynamicParams, :config do
     end
 
     it 'does not register an offense when accessing static parameter names' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create
             params.require(:user).permit(:user_id)
@@ -36,11 +36,11 @@ describe RuboCop::Cop::Betterment::DynamicParams, :config do
             params[:user_id]
           end
         end
-      DEF
+      RUBY
     end
 
     it 'does not register an offense when accessing non-params objects dynamically' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create
             dynamic_field = :something
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Betterment::DynamicParams, :config do
             really_not_params_I_swear[dynamic_field]
           end
         end
-      DEF
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/betterment/memoization_with_arguments_spec.rb
+++ b/spec/rubocop/cop/betterment/memoization_with_arguments_spec.rb
@@ -9,25 +9,25 @@ describe RuboCop::Cop::Betterment::MemoizationWithArguments, :config do
       'Remove memoization or refactor to remove arguments.'
   end
   let(:method_body) do
-    <<~DEF
+    <<~RUBY
       @test_method ||= 'yay'
       #{expected_offense}
-    DEF
+    RUBY
   end
   let(:memoized_block_body) do
-    <<~DEF
+    <<~RUBY
       @test_method ||= begin
       #{expected_offense}
         :yay
       end
-    DEF
+    RUBY
   end
   let(:method_def) do
-    <<~DEF
+    <<~RUBY
       def #{method_name}#{method_arguments}
       #{method_body.gsub(/^/, '  ')}
       end
-    DEF
+    RUBY
   end
 
   context 'without arguments' do
@@ -80,12 +80,12 @@ describe RuboCop::Cop::Betterment::MemoizationWithArguments, :config do
 
     context 'when memoized at the end after other lines of code' do
       let(:method_body) do
-        <<-DEF.strip
+        <<~RUBY.strip
         line 1
         line 2
         @test_method ||= 'yay'
         #{expected_offense}
-        DEF
+        RUBY
       end
 
       it 'registers an offense' do

--- a/spec/rubocop/cop/betterment/memoization_with_arguments_spec.rb
+++ b/spec/rubocop/cop/betterment/memoization_with_arguments_spec.rb
@@ -81,10 +81,10 @@ describe RuboCop::Cop::Betterment::MemoizationWithArguments, :config do
     context 'when memoized at the end after other lines of code' do
       let(:method_body) do
         <<~RUBY.strip
-        line 1
-        line 2
-        @test_method ||= 'yay'
-        #{expected_offense}
+          line 1
+          line 2
+          @test_method ||= 'yay'
+          #{expected_offense}
         RUBY
       end
 

--- a/spec/rubocop/cop/betterment/unsafe_job_spec.rb
+++ b/spec/rubocop/cop/betterment/unsafe_job_spec.rb
@@ -12,13 +12,13 @@ describe RuboCop::Cop::Betterment::UnsafeJob, :config do
     it 'registers an offense when perform takes unsafe parameters' do
       cop.sensitive_params = [:password]
 
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class RegistrationJob < ApplicationJob
           def perform(user_id:, password: nil)
             do_something
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(1)
       expect(cop.offenses.map(&:line)).to eq([2])
@@ -29,13 +29,13 @@ describe RuboCop::Cop::Betterment::UnsafeJob, :config do
     it 'does not register an offense when perform takes other parameters' do
       cop.sensitive_params = [:password]
 
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class RegistrationJob < ApplicationJob
           def perform(user_id:)
             do_something
           end
         end
-      DEF
+      RUBY
     end
   end
 
@@ -45,13 +45,13 @@ describe RuboCop::Cop::Betterment::UnsafeJob, :config do
       cop.class_regex = /.*Misc$/
       cop.sensitive_params = [:password]
 
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class AsyncMisc
           def perform(user_id:, password: nil)
             do_something
           end
         end
-      DEF
+      RUBY
       cop.class_regex = temp
 
       expect(cop.offenses.size).to be(1)
@@ -65,13 +65,13 @@ describe RuboCop::Cop::Betterment::UnsafeJob, :config do
       cop.class_regex = /.*Misc$/
       cop.sensitive_params = [:password]
 
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class DefaultJob
           def perform(user_id:, password: nil)
             do_something
           end
         end
-      DEF
+      RUBY
       cop.class_regex = temp
     end
   end
@@ -80,13 +80,13 @@ describe RuboCop::Cop::Betterment::UnsafeJob, :config do
     it 'registers an offense when perform takes unsafe parameters' do
       cop.sensitive_params = [:password]
 
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class RegistrationJob
           def perform(user_id:, password: nil)
             do_something
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(1)
       expect(cop.offenses.map(&:line)).to eq([2])
@@ -97,13 +97,13 @@ describe RuboCop::Cop::Betterment::UnsafeJob, :config do
     it 'does not register an offense when perform takes other parameters' do
       cop.sensitive_params = [:password]
 
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class RegistrationJob < ApplicationJob
           def perform(user_id:)
             do_something
           end
         end
-      DEF
+      RUBY
     end
   end
 
@@ -111,13 +111,13 @@ describe RuboCop::Cop::Betterment::UnsafeJob, :config do
     it 'does not register an offense when perform takes a sensitive parameter' do
       cop.sensitive_params = [:password]
 
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class SomethingElse
           def perform(user_id:, password: nil)
             do_something
           end
         end
-      DEF
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/betterment/unscoped_find_spec.rb
+++ b/spec/rubocop/cop/betterment/unscoped_find_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
 
   context 'when searching for records' do
     it 'registers an offense when using user input' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create
             # find all Secret records matching a particular secret_id
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
             Secret.find_by(user: params[:user_id])
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(2)
       expect(cop.offenses.map(&:line)).to eq([4, 5])
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
     end
 
     it 'registers an offense when using user input wrapped by a method' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def secret_id
             params[:secret_id]
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
             Secret.find_by(user: find_params[:user_id])
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(2)
       expect(cop.offenses.map(&:line)).to eq([12, 13])
@@ -61,7 +61,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
     end
 
     it 'registers an offense when passing user input to a custom scope' do
-      inspect_source(<<-DEF)
+      inspect_source(<<~RUBY)
         class Application
           def create
             # find all Secrets in the "active" scope
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
             Secret.active.find_by(user: params[:user_id])
           end
         end
-      DEF
+      RUBY
 
       expect(cop.offenses.size).to be(2)
       expect(cop.offenses.map(&:line)).to eq([4, 5])
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
     end
 
     it 'does not register an offense when trust chaining even with user input' do
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create
             current_user.secrets.find(params[:secret_id])
@@ -87,7 +87,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
             current_user.secrets.active.find_by(user: params[:user_id])
           end
         end
-      DEF
+      RUBY
     end
 
     it 'does not register an offense when searching for unauthenticated models' do
@@ -97,7 +97,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
       # if posts is a table with strictly public content, we can add the model
       # to the list of unauthenticated models so the cop won't flag any finds
       # against it.
-      expect_no_offenses(<<-DEF)
+      expect_no_offenses(<<~RUBY)
         class Application
           def create
             Post.find(params[:post_id])
@@ -106,7 +106,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
             Post.active.find_by(params[:post_id])
           end
         end
-      DEF
+      RUBY
       cop.unauthenticated_models = temp
     end
   end

--- a/spec/rubocop/cop/betterment/utils/parser_spec.rb
+++ b/spec/rubocop/cop/betterment/utils/parser_spec.rb
@@ -3,57 +3,57 @@ require 'spec_helper'
 describe RuboCop::Cop::Utils::Parser do
   context 'when processing a statement' do
     it 'finds the root token for a bare send' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         method(:hello_world)
-      DEF
+      RUBY
 
       expect(described_class.get_root_token(node)).to eq(:method)
     end
 
     it 'finds the root token for a send type' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         params.permit(:parameter)
-      DEF
+      RUBY
 
       expect(described_class.get_root_token(node)).to eq(:params)
     end
 
     it 'finds the root token for a chained send' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         params.fetch(:parent, {}).permit(:username, :password)
-      DEF
+      RUBY
 
       expect(described_class.get_root_token(node)).to eq(:params)
     end
 
     it 'finds the root token for a nested send' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         SomeObject.new(params.permit(:username, :password))
-      DEF
+      RUBY
 
       expect(described_class.get_root_token(node)).to eq(:SomeObject)
     end
 
     it 'finds the root token for a send to a self node' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         self.parameter = 1
-      DEF
+      RUBY
 
       expect(described_class.get_root_token(node)).to eq(:self)
     end
 
     it 'finds the root token for a send via block pass' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         some_method(&another_method)
-      DEF
+      RUBY
 
       expect(described_class.get_root_token(node)).to eq(:some_method)
     end
 
     it 'finds the root token for a send to a module' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         Module::method.call(1, 2, 3)
-      DEF
+      RUBY
 
       expect(described_class.get_root_token(node)).to eq(:Module)
     end
@@ -61,12 +61,12 @@ describe RuboCop::Cop::Utils::Parser do
 
   context 'when looking for return values' do
     it 'finds all the explicit return values' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         def some_method(arg)
           return 123 if arg.this?
           return 456 if arg.that?
         end
-      DEF
+      RUBY
 
       node_123 = parse_source("123").ast
       node_456 = parse_source("456").ast
@@ -75,11 +75,11 @@ describe RuboCop::Cop::Utils::Parser do
     end
 
     it 'finds all the implicit return values' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         def some_method(arg)
           true if arg.test?
         end
-      DEF
+      RUBY
 
       node_true = parse_source("true").ast
 
@@ -87,14 +87,14 @@ describe RuboCop::Cop::Utils::Parser do
     end
 
     it 'finds all the implicit and explicit return values' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         def some_method(arg)
           return 123 if arg.this?
           return 456 if arg.that?
 
           789
         end
-      DEF
+      RUBY
 
       node_123 = parse_source("123").ast
       node_456 = parse_source("456").ast
@@ -104,11 +104,11 @@ describe RuboCop::Cop::Utils::Parser do
     end
 
     it 'finds a compound statement return value' do
-      node = parse_source(<<-DEF).ast
+      node = parse_source(<<~RUBY).ast
         def some_method
           self.size + 1
         end
-      DEF
+      RUBY
 
       node_add = parse_source("self.size + 1").ast
 


### PR DESCRIPTION
The following code was incorrectly being recognized as an offense:
```ruby
class MyBusinessLogic
  class MyJob < ApplicationJob
    def perform
      MyBusinessLogic.call
    end
  end
end
```

This was happening because `Node#descendants` returns all of the nodes descendants (recursively), rather than the node's immediate children. 