### PR TITLE
Update range_with calls to pass range parameter

### DIFF
--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.2.2"
+  s.version = "1.3.1"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/lib/rubocop/cop/betterment/hardcoded_id.rb
+++ b/lib/rubocop/cop/betterment/hardcoded_id.rb
@@ -93,7 +93,7 @@ module RuboCop
         def with_comma(attribute)
           range = attribute.location.expression
           range = range_with_surrounding_space(range: range)
-          range_with_surrounding_comma(range: range, :left)
+          range_with_surrounding_comma(range, :left)
         end
       end
     end

--- a/lib/rubocop/cop/betterment/hardcoded_id.rb
+++ b/lib/rubocop/cop/betterment/hardcoded_id.rb
@@ -92,8 +92,8 @@ module RuboCop
 
         def with_comma(attribute)
           range = attribute.location.expression
-          range = range_with_surrounding_space(range)
-          range_with_surrounding_comma(range, :left)
+          range = range_with_surrounding_space(range: range)
+          range_with_surrounding_comma(range: range, :left)
         end
       end
     end


### PR DESCRIPTION
Should fix:

```
An error occurred while Betterment/HardcodedID cop...
wrong number of arguments (given 1, expected 0; required keyword: range)
/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rubocop-1.23.0/lib/rubocop/cop/mixin/range_help.rb:54:in `range_with_surrounding_space'
```