### PR TITLE
feat(rubocop-rspec): disable FactoryBot SyntaxMethods rule

### DIFF
--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.3.1"
+  s.version = "1.4.0"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -217,6 +217,9 @@ RSpec/ExampleWording:
 RSpec/ExpectChange:
   EnforcedStyle: 'block'
 
+RSpec/FactoryBot/SyntaxMethods:
+  Enabled: false
+
 RSpec/FilePath:
   Enabled: false
 

--- a/lib/rubocop/cop/betterment/implicit_redirect_type.rb
+++ b/lib/rubocop/cop/betterment/implicit_redirect_type.rb
@@ -62,7 +62,7 @@ module RuboCop
         private
 
         def routes_file?
-          Pathname.new(processed_source.buffer.name).basename.to_s == ROUTES_FILE_NAME
+          Pathname.new(processed_source.file_path).basename.to_s == ROUTES_FILE_NAME
         end
       end
     end

--- a/lib/rubocop/cop/betterment/non_standard_actions.rb
+++ b/lib/rubocop/cop/betterment/non_standard_actions.rb
@@ -17,7 +17,7 @@ module RuboCop
         PATTERN
 
         def not_to_or_action?(sym)
-          !%i(to action).include?(sym)
+          !%i(to action).include?(sym) # rubocop:disable Style/InverseMethods
         end
 
         # @!method route_to(node)

--- a/lib/rubocop/cop/betterment/spec_helper_required_outside_spec_dir.rb
+++ b/lib/rubocop/cop/betterment/spec_helper_required_outside_spec_dir.rb
@@ -27,7 +27,7 @@ module RuboCop
         private
 
         def spec_directory?
-          Pathname.new(processed_source.buffer.name)
+          Pathname.new(processed_source.file_path)
             .relative_path_from(Pathname.pwd)
             .to_s
             .start_with?("spec#{File::SEPARATOR}")

--- a/lib/rubocop/cop/betterment/unscoped_find.rb
+++ b/lib/rubocop/cop/betterment/unscoped_find.rb
@@ -45,7 +45,7 @@ module RuboCop
                 find?(node) ||
                 custom_scope_find?(node) ||
                 static_method_name(node.method_name)
-            ) && !@unauthenticated_models.include?(Utils::Parser.get_root_token(node))
+            ) && !@unauthenticated_models.include?(Utils::Parser.get_root_token(node)) # rubocop:disable Style/InverseMethods
 
           add_offense(node) if find_param_arg(arg_nodes)
         end


### PR DESCRIPTION
Based on feedback from an automated linter fix from `rubocop-rspec` v2.7 (https://github.com/Betterment/test_track/pull/182#discussion_r1117806216), creating this PR to start a conversation around disabling the rule for apps that depend on this gem going forward. 

[Docs for the rule being disabled](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/SyntaxMethods)

/cc: @smudge 