### PR TITLE
Disable Style/IfUnlessModifier

### DIFF
--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.4.2"
+  s.version = "1.4.3"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -280,6 +280,9 @@ Style/FrozenStringLiteralComment:
 Style/GuardClause:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Style/Lambda:
   Enabled: false
 

--- a/lib/rubocop/cop/betterment/non_standard_actions.rb
+++ b/lib/rubocop/cop/betterment/non_standard_actions.rb
@@ -17,7 +17,7 @@ module RuboCop
         PATTERN
 
         def not_to_or_action?(sym)
-          !%i(to action).include?(sym) # rubocop:disable Style/InverseMethods
+          !%i(to action).include?(sym)
         end
 
         # @!method route_to(node)

--- a/lib/rubocop/cop/betterment/site_prism_loaded.rb
+++ b/lib/rubocop/cop/betterment/site_prism_loaded.rb
@@ -16,7 +16,7 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.children[2].source_range, 'be_loaded')
+            corrector.replace(node.children[2], 'be_loaded')
           end
         end
       end

--- a/lib/rubocop/cop/betterment/unscoped_find.rb
+++ b/lib/rubocop/cop/betterment/unscoped_find.rb
@@ -45,7 +45,7 @@ module RuboCop
                 find?(node) ||
                 custom_scope_find?(node) ||
                 static_method_name(node.method_name)
-            ) && !@unauthenticated_models.include?(Utils::Parser.get_root_token(node)) # rubocop:disable Style/InverseMethods
+            ) && !@unauthenticated_models.include?(Utils::Parser.get_root_token(node))
 
           add_offense(node) if find_param_arg(arg_nodes)
         end


### PR DESCRIPTION
The `Style/IfUnlessModifier` encourages us to use the modifier form of if or unless.

```ruby
# bad
if ready?
  perform_action!
end

# good
perform_action! if ready?
```

Generally, I think most people agree with this. However, our `Layout/LineLength` is set to a very generous 140. So, Rubocop would also encourage us to put this on one line:

```ruby
# rubocop says bad?
unless user.profile_configuration.ready?
  redirect_to user_profile_configuration_path, flash: { error: "We're setting up your profile." }
end

# rubocop says good?
redirect_to user_profile_configuration_path, flash: { error: "We're setting up your profile." } unless user.profile_configuration.ready?
```

As a reader, these conditionals are the most important thing for me to see. I think we should leave the decision to use a modifier up to the author.