### PR TITLE
Disable new cop suggestions

### DIFF
--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.4.3"
+  s.version = "1.4.4"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -20,7 +20,8 @@ AllCops:
   DisplayStyleGuide: true
   DisplayCopNames: true
   NewCops: enable
-  SuggestExtensions: false
+  SuggestExtensions:
+    rubocop-capybara: false
 
 Betterment:
   StyleGuideBaseURL: https://github.com/Betterment/betterlint

--- a/config/default.yml
+++ b/config/default.yml
@@ -20,6 +20,7 @@ AllCops:
   DisplayStyleGuide: true
   DisplayCopNames: true
   NewCops: enable
+  SuggestExtensions: false
 
 Betterment:
   StyleGuideBaseURL: https://github.com/Betterment/betterlint


### PR DESCRIPTION
This is really annoying:

```
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-capybara (https://rubygems.org/gems/rubocop-capybara)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```