### PR TITLE
Fix warning when running betterlint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1]
+        ruby: [2.7, 3.0, 3.1]
         gemfile:
           - Gemfile
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,4 +7,4 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_dependency "rubocop-performance"
   s.add_dependency "rubocop-rails"
   s.add_dependency "rubocop-rake"
-  s.add_dependency "rubocop-rspec", ">= 2.7"
+  s.add_dependency "rubocop-rspec", ">= 2.22"
 end

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.4.4"
+  s.version = "1.4.5"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "STYLEGUIDE.md", "config/*.yml", "lib/**/*.rb"]
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 2.7"
 
   s.add_dependency "rubocop", "> 1.0"
   s.add_dependency "rubocop-performance"

--- a/config/default.yml
+++ b/config/default.yml
@@ -219,7 +219,7 @@ RSpec/ExampleWording:
 RSpec/ExpectChange:
   EnforcedStyle: 'block'
 
-RSpec/FactoryBot/SyntaxMethods:
+FactoryBot/SyntaxMethods:
   Enabled: false
 
 RSpec/FilePath:

--- a/lib/rubocop/cop/betterment/utils/parser.rb
+++ b/lib/rubocop/cop/betterment/utils/parser.rb
@@ -59,9 +59,9 @@ module RuboCop
         end
 
         def self.explicit_returns(node)
-          node.descendants.select(&:return_type?).map { |x|
+          node.descendants.select(&:return_type?).filter_map { |x|
             x&.children&.first
-          }.compact
+          }
         end
 
         def self.params_from_arguments(arguments) # rubocop:disable Metrics/PerceivedComplexity

--- a/lib/rubocop/cop/betterment/utils/parser.rb
+++ b/lib/rubocop/cop/betterment/utils/parser.rb
@@ -59,9 +59,9 @@ module RuboCop
         end
 
         def self.explicit_returns(node)
-          node.descendants.select(&:return_type?).filter_map { |x|
+          node.descendants.select(&:return_type?).filter_map do |x|
             x&.children&.first
-          }
+          end
         end
 
         def self.params_from_arguments(arguments) # rubocop:disable Metrics/PerceivedComplexity


### PR DESCRIPTION
betterlint-1.4.4/config/default.yml: RSpec/FactoryBot/SyntaxMethods has the wrong namespace - should be FactoryBot