### PR TITLE
Exclude FactoryBot/ConsistentParenthesesStyle

### DIFF
--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.4.5"
+  s.version = "1.4.6"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -76,6 +76,9 @@ Betterment/HardcodedID:
   AutoCorrect: false
   SafeAutoCorrect: false
 
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: false
+
 Layout/ParameterAlignment:
   Enabled: false
 


### PR DESCRIPTION
This was causing hundreds of additions to our rubocop-todo files, and doesn't feel like a worthwhile style to enforce (we don't enforce paren consistency elsewhere).

I haven't had any issues with churn in our factory bot parens usages, and this cop is missing the reasonable config of being able to have single arg factory bot calls without parens. 

I think we should disable this until we have an easier way to autoformat consistently.

/no-platform