### PR TITLE
Disable RSpec/IndexedLet and RSpec/BeEq

### DIFF
--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.4.6"
+  s.version = "1.4.7"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -188,6 +188,9 @@ Rails/HttpPositionalArguments:
 
 Rails/OutputSafety:
   Enabled: true
+  
+RSpec/BeEq:
+  Enabled: false
 
 RSpec/Capybara/FeatureMethods:
   Enabled: false
@@ -229,6 +232,9 @@ RSpec/FilePath:
   Enabled: false
 
 RSpec/HookArgument:
+  Enabled: false
+  
+RSpec/IndexedLet:
   Enabled: false
 
 RSpec/ItBehavesLike:


### PR DESCRIPTION
/no-platform

Disable a couple of new RSpec cops that have a lot of violations in our codebase and provide questionable or marginable value.

IndexedLet prevents numbers at the end of let variables. I think there are valid cases where using numbers is fine, and I can't say I've encountered specs where the use of them has impeded my ability to understand what's happening.

BeEq flags cases where `be eq` is used instead of just `be` when `be` would work. In ruby we rarely use identity based equality, and I think using it here simply because we can will lead to more confusion and bugs then sticking with `eq`. I personally would restrict use of `be` to specific cases where the identity of the object matters, like when we care about a particular instance of an object being returned.