### PR TITLE
Change Style/NumberedParameters cop to be disallowed

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -308,6 +308,10 @@ Style/MissingElse:
   Enabled: true
   EnforcedStyle: case
 
+Style/NumberedParameters:
+  Enabled: true
+  EnforcedStyle: disallow
+
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%I': ()


### PR DESCRIPTION
### Summary

This branch changes the numbered parameters feature to **not** be allowed. We [discussed this](https://betterment.slack.com/archives/C5PL74XGV/p1692719844839739) and decided it did not provide enough value for the confusion it may cause.

So, instead of this, using the _implicit_ numbered parameter `_1`:

```ruby
[1, 2, 3].map { _1 * 2 }
```

We should write this, using an _explicit_ variable in the block:

```ruby
[1, 2, 3].map { |i| i * 2 }
```