### PR TITLE
Change Style/FrozenStringLiteralComment cop to be enabled

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'bundler/setup'
 rescue LoadError

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.5.0"
+  s.version = "1.6.0"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -292,7 +292,7 @@ Style/Documentation:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
 
 Style/GuardClause:
   Enabled: false

--- a/lib/rubocop/cop/betterment.rb
+++ b/lib/rubocop/cop/betterment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop'
 require 'rubocop/cop/betterment/utils/parser'
 require 'rubocop/cop/betterment/utils/method_return_table'

--- a/lib/rubocop/cop/betterment/active_job_performable.rb
+++ b/lib/rubocop/cop/betterment/active_job_performable.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
       class ActiveJobPerformable < Cop
-        MSG = <<~DOC.freeze
+        MSG = <<~DOC
           Classes that are "performable" should be ActiveJobs
 
           class MyJob < ApplicationJob

--- a/lib/rubocop/cop/betterment/allowlist_blocklist.rb
+++ b/lib/rubocop/cop/betterment/allowlist_blocklist.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 # rubocop:disable Betterment/AllowlistBlocklist
 module RuboCop
   module Cop
     module Betterment
       class AllowlistBlocklist < Cop
-        MSG = <<-DOC.freeze
+        MSG = <<-DOC
           Avoid usages of whitelist & blacklist, in favor of more inclusive and descriptive language.
           For consistency, favor 'allowlist' and 'blocklist' where possible, but other terms (such as
           denylist, ignorelist, warnlist, safelist, etc) may be appropriate, depending on the use case.

--- a/lib/rubocop/cop/betterment/authorization_in_controller.rb
+++ b/lib/rubocop/cop/betterment/authorization_in_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
@@ -5,7 +7,7 @@ module RuboCop
         attr_accessor :unsafe_parameters, :unsafe_regex
 
         # MSG_UNSAFE_CREATE = 'Model created/updated using unsafe parameters'.freeze
-        MSG_UNSAFE_CREATE = <<~MSG.freeze
+        MSG_UNSAFE_CREATE = <<~MSG
           Model created/updated using unsafe parameters.
           Please query for the associated record in a way that enforces authorization (e.g. "trust-root chaining"),
           and then pass the resulting object into your model instead of the unsafe parameter.

--- a/lib/rubocop/cop/betterment/dynamic_params.rb
+++ b/lib/rubocop/cop/betterment/dynamic_params.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
       class DynamicParams < Cop
-        MSG_DYNAMIC_PARAMS = <<~MSG.freeze
+        MSG_DYNAMIC_PARAMS = <<~MSG
           Parameter names accessed dynamically, cannot determine safeness. Please inline the keys explicitly when calling `permit` or when accessing `params` like a hash.
 
           See here for more information on this error:

--- a/lib/rubocop/cop/betterment/hardcoded_id.rb
+++ b/lib/rubocop/cop/betterment/hardcoded_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
@@ -5,7 +7,7 @@ module RuboCop
         include RangeHelp
         extend AutoCorrector
 
-        MSG = 'Hardcoded IDs cause flaky tests. Use a sequence instead.'.freeze
+        MSG = 'Hardcoded IDs cause flaky tests. Use a sequence instead.'
 
         # @!method key(node)
         def_node_matcher :key, '/^id$|_id$/'

--- a/lib/rubocop/cop/betterment/implicit_redirect_type.rb
+++ b/lib/rubocop/cop/betterment/implicit_redirect_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
@@ -13,10 +15,10 @@ module RuboCop
       #   get '/', redirect('/dashboard', status: 301)
       #   get(status: 302) { |params, request| '/dashboard' }
       class ImplicitRedirectType < Cop
-        ROUTES_FILE_NAME = 'routes.rb'.freeze
+        ROUTES_FILE_NAME = 'routes.rb'
         MSG =
           'Rails will create a permanent (301) redirect, which is dangerous. ' \
-          'Please specify your desired status, e.g. redirect(..., status: 302)'.freeze
+          'Please specify your desired status, e.g. redirect(..., status: 302)'
 
         # redirect('/')
         def_node_matcher :arg_form_without_options?, <<-PATTERN

--- a/lib/rubocop/cop/betterment/memoization_with_arguments.rb
+++ b/lib/rubocop/cop/betterment/memoization_with_arguments.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
       class MemoizationWithArguments < Cop
         MSG = 'Memoized method `%<method>s` accepts arguments, ' \
               'which may cause it to return a stale result. ' \
-              'Remove memoization or refactor to remove arguments.'.freeze
+              'Remove memoization or refactor to remove arguments.'
 
         def self.node_pattern
           memo_assign = '(or_asgn $(ivasgn _) _)'

--- a/lib/rubocop/cop/betterment/non_standard_actions.rb
+++ b/lib/rubocop/cop/betterment/non_standard_actions.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
       class NonStandardActions < Cop
-        MSG_GENERAL = 'Use a new controller instead of custom actions.'.freeze
+        MSG_GENERAL = 'Use a new controller instead of custom actions.'
         MSG_RESOURCE_ONLY = "Resource route refers to a non-standard action in it's 'only:' param. #{MSG_GENERAL}".freeze
         MSG_ROUTE_TO = "Route goes to a non-standard controller action. #{MSG_GENERAL}".freeze
 

--- a/lib/rubocop/cop/betterment/site_prism_loaded.rb
+++ b/lib/rubocop/cop/betterment/site_prism_loaded.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
       class SitePrismLoaded < Cop
-        MSG = 'Use `be_loaded` instead of `be_displayed`'.freeze
+        MSG = 'Use `be_loaded` instead of `be_displayed`'
 
         def_node_matcher :be_displayed_call?, <<-PATTERN
           (send (send nil? :expect _) _ (send nil? :be_displayed))

--- a/lib/rubocop/cop/betterment/spec_helper_required_outside_spec_dir.rb
+++ b/lib/rubocop/cop/betterment/spec_helper_required_outside_spec_dir.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
@@ -13,7 +15,7 @@ module RuboCop
       #   spec/models/my_class_spec.rb
       #   require 'rails_helper'
       class SpecHelperRequiredOutsideSpecDir < Cop
-        MSG = 'Spec helper required outside of a spec/ directory.'.freeze
+        MSG = 'Spec helper required outside of a spec/ directory.'
 
         def_node_matcher :requires_spec_helper?, <<-PATTERN
           (send nil? :require

--- a/lib/rubocop/cop/betterment/timeout.rb
+++ b/lib/rubocop/cop/betterment/timeout.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
       class Timeout < Cop
-        MSG = 'Using Timeout.timeout without a custom exception can prevent rescue blocks from executing'.freeze
+        MSG = 'Using Timeout.timeout without a custom exception can prevent rescue blocks from executing'
 
         def_node_matcher :timeout_call?, <<-PATTERN
           (send (const nil? :Timeout) :timeout _)

--- a/lib/rubocop/cop/betterment/unsafe_job.rb
+++ b/lib/rubocop/cop/betterment/unsafe_job.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
       class UnsafeJob < Cop
         attr_accessor :sensitive_params, :class_regex
 
-        MSG = <<~MSG.freeze
+        MSG = <<~MSG
           This job takes a parameter that will end up serialized in plaintext. Do not pass sensitive data as bare arguments into jobs.
 
           See here for more information on this error:

--- a/lib/rubocop/cop/betterment/unscoped_find.rb
+++ b/lib/rubocop/cop/betterment/unscoped_find.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
       class UnscopedFind < Cop
         attr_accessor :unauthenticated_models
 
-        MSG = <<~MSG.freeze
+        MSG = <<~MSG
           Records are being retrieved directly using user input.
           Please query for the associated record in a way that enforces authorization (e.g. "trust-root chaining").
 

--- a/lib/rubocop/cop/betterment/utils/hardcoded_attribute.rb
+++ b/lib/rubocop/cop/betterment/utils/hardcoded_attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment

--- a/lib/rubocop/cop/betterment/utils/method_return_table.rb
+++ b/lib/rubocop/cop/betterment/utils/method_return_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment

--- a/lib/rubocop/cop/betterment/utils/parser.rb
+++ b/lib/rubocop/cop/betterment/utils/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment

--- a/lib/rubocop/cop/betterment/vague_serialize.rb
+++ b/lib/rubocop/cop/betterment/vague_serialize.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module Betterment
       class VagueSerialize < Base
         MSG = 'Active Record models with serialized columns should specify which ' \
-              'deserializer to use instead of falling back to the default.'.freeze
+              'deserializer to use instead of falling back to the default.'
 
         # @!method serialize?(node)
         def_node_matcher :serialize?, <<-PATTERN

--- a/spec/rubocop/cop/betterment/active_job_performable_spec.rb
+++ b/spec/rubocop/cop/betterment/active_job_performable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::ActiveJobPerformable, :config do

--- a/spec/rubocop/cop/betterment/allowlist_blocklist_spec.rb
+++ b/spec/rubocop/cop/betterment/allowlist_blocklist_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::AllowlistBlocklist, :config do

--- a/spec/rubocop/cop/betterment/authorization_in_controller_spec.rb
+++ b/spec/rubocop/cop/betterment/authorization_in_controller_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::AuthorizationInController, :config do
   let(:offense_create) do
-    <<~MSG.freeze
+    <<~MSG
       Model created/updated using unsafe parameters.
       Please query for the associated record in a way that enforces authorization (e.g. "trust-root chaining"),
       and then pass the resulting object into your model instead of the unsafe parameter.

--- a/spec/rubocop/cop/betterment/dynamic_params_spec.rb
+++ b/spec/rubocop/cop/betterment/dynamic_params_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 describe RuboCop::Cop::Betterment::DynamicParams, :config do
   let(:offense_dynamic_parameter) do
-    <<~MSG.freeze
+    <<~MSG
       Parameter names accessed dynamically, cannot determine safeness. Please inline the keys explicitly when calling `permit` or when accessing `params` like a hash.
 
       See here for more information on this error:

--- a/spec/rubocop/cop/betterment/hardcoded_id_spec.rb
+++ b/spec/rubocop/cop/betterment/hardcoded_id_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::HardcodedID, :config do

--- a/spec/rubocop/cop/betterment/implicit_redirect_type_spec.rb
+++ b/spec/rubocop/cop/betterment/implicit_redirect_type_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RuboCop::Cop::Betterment::ImplicitRedirectType, :config do

--- a/spec/rubocop/cop/betterment/memoization_with_arguments_spec.rb
+++ b/spec/rubocop/cop/betterment/memoization_with_arguments_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::MemoizationWithArguments, :config do

--- a/spec/rubocop/cop/betterment/non_standard_actions_spec.rb
+++ b/spec/rubocop/cop/betterment/non_standard_actions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::NonStandardActions, :betterlint_config do

--- a/spec/rubocop/cop/betterment/server_error_assertion_spec.rb
+++ b/spec/rubocop/cop/betterment/server_error_assertion_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::ServerErrorAssertion, :config do

--- a/spec/rubocop/cop/betterment/site_prism_loaded_spec.rb
+++ b/spec/rubocop/cop/betterment/site_prism_loaded_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::SitePrismLoaded, :config do

--- a/spec/rubocop/cop/betterment/spec_helper_required_outside_spec_dir_spec.rb
+++ b/spec/rubocop/cop/betterment/spec_helper_required_outside_spec_dir_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RuboCop::Cop::Betterment::SpecHelperRequiredOutsideSpecDir, :config do

--- a/spec/rubocop/cop/betterment/timeout_spec.rb
+++ b/spec/rubocop/cop/betterment/timeout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::Timeout, :config do

--- a/spec/rubocop/cop/betterment/unsafe_job_spec.rb
+++ b/spec/rubocop/cop/betterment/unsafe_job_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 describe RuboCop::Cop::Betterment::UnsafeJob, :config do
   let(:offense_unsafe_job) do
-    <<~MSG.freeze
+    <<~MSG
       This job takes a parameter that will end up serialized in plaintext. Do not pass sensitive data as bare arguments into jobs.
 
       See here for more information on this error:

--- a/spec/rubocop/cop/betterment/unscoped_find_spec.rb
+++ b/spec/rubocop/cop/betterment/unscoped_find_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::UnscopedFind, :config do
   let(:offense_unscoped_find) do
-    <<~MSG.freeze
+    <<~MSG
       Records are being retrieved directly using user input.
       Please query for the associated record in a way that enforces authorization (e.g. "trust-root chaining").
 

--- a/spec/rubocop/cop/betterment/utils/hardcoded_attribute_spec.rb
+++ b/spec/rubocop/cop/betterment/utils/hardcoded_attribute_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::Utils::HardcodedAttribute do

--- a/spec/rubocop/cop/betterment/utils/method_return_table_spec.rb
+++ b/spec/rubocop/cop/betterment/utils/method_return_table_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::Utils::MethodReturnTable do

--- a/spec/rubocop/cop/betterment/utils/parser_spec.rb
+++ b/spec/rubocop/cop/betterment/utils/parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::Utils::Parser do

--- a/spec/rubocop/cop/betterment/vague_serialize_spec.rb
+++ b/spec/rubocop/cop/betterment/vague_serialize_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe RuboCop::Cop::Betterment::VagueSerialize, :config do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop'
 require 'rubocop/cop/betterment'
 require 'rubocop/rspec/support'

--- a/spec/support/betterlint_config.rb
+++ b/spec/support/betterlint_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 BETTERLINT_CONFIG_PATH = File.expand_path('../../config/default.yml', __dir__)
 
 RSpec.shared_context 'betterlint_config', :betterlint_config do


### PR DESCRIPTION
### Summary

This branch changes rubocop to ensure there is a frozen literal string comment at the top of every ruby file.
