### PR TITLE
Change Layout/ClosingParenthesisIndentation to be enabled

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -86,7 +86,7 @@ Layout/CaseIndentation:
   IndentOneStep: true
 
 Layout/ClosingParenthesisIndentation:
-  Enabled: false
+  Enabled: true
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent

--- a/lib/rubocop/cop/betterment/unscoped_find.rb
+++ b/lib/rubocop/cop/betterment/unscoped_find.rb
@@ -44,9 +44,9 @@ module RuboCop
           _, _, *arg_nodes = *node # rubocop:disable InternalAffairs/NodeDestructuring
           return unless
             (
-                find?(node) ||
-                custom_scope_find?(node) ||
-                static_method_name(node.method_name)
+              find?(node) ||
+              custom_scope_find?(node) ||
+              static_method_name(node.method_name)
             ) && !@unauthenticated_models.include?(Utils::Parser.get_root_token(node))
 
           add_offense(node) if find_param_arg(arg_nodes)


### PR DESCRIPTION
### Summary

- [x] Fix Betterment::UnscopedFind code to use 2 space indent
- [x] Change Layout/ClosingParenthesisIndentation to be enabled

/domain @smudge @effron @willlockwood
/platform @Betterment/ruby-platform-reviewers

### Description

This branch enables the Layout/ClosingParenthesisIndentation cop which was curiously disabled in the initial creation of betterlint.
