### PR TITLE
feat: Expand `UnscopedFind` offenses in "graphql" namespaces

### DIFF
--- a/lib/rubocop/cop/betterment/unscoped_find.rb
+++ b/lib/rubocop/cop/betterment/unscoped_find.rb
@@ -49,10 +49,17 @@ module RuboCop
                 static_method_name(node.method_name)
             ) && !@unauthenticated_models.include?(Utils::Parser.get_root_token(node))
 
-          add_offense(node) if find_param_arg(arg_nodes)
+          add_offense(node) if find_param_arg(arg_nodes) || graphql_namespace?(node)
         end
 
         private
+
+        def graphql_namespace?(node)
+          node
+            .ancestors
+            .select { |n| n.class_type? || n.module_type? }
+            .any? { |n| n.identifier.to_s.downcase.include?("graphql") }
+        end
 
         def find_param_arg(arg_nodes)
           return unless arg_nodes

--- a/lib/rubocop/cop/betterment/unscoped_find.rb
+++ b/lib/rubocop/cop/betterment/unscoped_find.rb
@@ -31,6 +31,10 @@ module RuboCop
           (send (const ... _) {#{FINDS.map(&:inspect).join(' ')}} ...)
         PATTERN
 
+        def_node_search :find_graphql_namespace_nodes, <<~PATTERN, name: GRAPHQL_PATTERN
+          (const _ %name)
+        PATTERN
+
         def initialize(config = nil, options = nil)
           super(config, options)
           config = @config.for_cop(self)
@@ -50,18 +54,19 @@ module RuboCop
                 static_method_name(node.method_name)
             ) && !@unauthenticated_models.include?(Utils::Parser.get_root_token(node))
 
-          add_offense(node) if find_param_arg(arg_nodes) || graphql_namespace?(node)
+          add_offense(node) if find_param_arg(arg_nodes) || graphql_file? || graphql_namespace?(node)
         end
 
         private
 
-        def graphql_namespace?(node)
-          return true if processed_source.path&.match?(GRAPHQL_PATTERN)
+        def graphql_file?
+          processed_source.path&.match?(GRAPHQL_PATTERN)
+        end
 
+        def graphql_namespace?(node)
           node
-            .ancestors
-            .select { |n| n.class_type? || n.module_type? }
-            .any? { |n| n.identifier.to_s.match?(GRAPHQL_PATTERN) }
+            .each_ancestor(:class, :module)
+            .any? { |ancestor| find_graphql_namespace_nodes(ancestor).any? }
         end
 
         def find_param_arg(arg_nodes)

--- a/lib/rubocop/cop/betterment/unscoped_find.rb
+++ b/lib/rubocop/cop/betterment/unscoped_find.rb
@@ -58,7 +58,7 @@ module RuboCop
           node
             .ancestors
             .select { |n| n.class_type? || n.module_type? }
-            .any? { |n| n.identifier.to_s.downcase.include?("graphql") }
+            .any? { |n| n.identifier.to_s.match(/\bGraphQL\b/i) }
         end
 
         def find_param_arg(arg_nodes)

--- a/lib/rubocop/cop/betterment/unscoped_find.rb
+++ b/lib/rubocop/cop/betterment/unscoped_find.rb
@@ -21,6 +21,7 @@ module RuboCop
         MSG
         METHOD_PATTERN = /^find_by_(.+?)(!)?$/
         FINDS = %i(find find_by find_by! where).freeze
+        GRAPHQL_PATTERN = /\bGraphQL\b/i
 
         def_node_matcher :custom_scope_find?, <<-PATTERN
           (send (send (const ... _) ...) {#{FINDS.map(&:inspect).join(' ')}} ...)
@@ -55,10 +56,12 @@ module RuboCop
         private
 
         def graphql_namespace?(node)
+          return true if processed_source.path&.match(GRAPHQL_PATTERN)
+
           node
             .ancestors
             .select { |n| n.class_type? || n.module_type? }
-            .any? { |n| n.identifier.to_s.match(/\bGraphQL\b/i) }
+            .any? { |n| n.identifier.to_s.match(GRAPHQL_PATTERN) }
         end
 
         def find_param_arg(arg_nodes)

--- a/lib/rubocop/cop/betterment/unscoped_find.rb
+++ b/lib/rubocop/cop/betterment/unscoped_find.rb
@@ -56,12 +56,12 @@ module RuboCop
         private
 
         def graphql_namespace?(node)
-          return true if processed_source.path&.match(GRAPHQL_PATTERN)
+          return true if processed_source.path&.match?(GRAPHQL_PATTERN)
 
           node
             .ancestors
             .select { |n| n.class_type? || n.module_type? }
-            .any? { |n| n.identifier.to_s.match(GRAPHQL_PATTERN) }
+            .any? { |n| n.identifier.to_s.match?(GRAPHQL_PATTERN) }
         end
 
         def find_param_arg(arg_nodes)

--- a/spec/rubocop/cop/betterment/unscoped_find_spec.rb
+++ b/spec/rubocop/cop/betterment/unscoped_find_spec.rb
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Betterment::UnscopedFind, :config do
         end
 
         module Foo
-          module GraphQL
+          module Graphql
             class Application
               def create
                 user_id = 1


### PR DESCRIPTION
### Summary

Currently, the `UnscopedFind` cop currently identifies violations of trust-root-chaining by looking for different types of custom finds that contain "user input"—specifically, that a non-trust-root-chained find contains a direct or indirect reference to `params`. For ruby applications using GraphQL, this cop will almost never find violations, since GraphQL implementations will idiomatically have no reference to `params`.

Here, I'm attempting to bridge the `UnscopedFind` gap for GraphQL implementations by also considering relevant find nodes in violation with the cop when inside of a namespace matching "graphql". Since popular packages like `graphql-ruby` promote the usage of `GraphQL` namespaces, I think this is the highest-fidelity fix I can imagine to expand the relevance of this cop outside of REST, without fully removing the `params`-based logic for the current cop.

/domain @smudge @effron
/domain @lindan-betterment
/platform @Betterment/ruby-platform-reviewers