### PR TITLE
chore: Update version to `1.7.0`

### DIFF
--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.6.0"
+  s.version = "1.7.0"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"


### PR DESCRIPTION
This PR updates the betterlint version to `1.7.0` to include #29 and #30 in a new gem release.