### PR TITLE
Fix edge cases in status code autocorrection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    betterlint (1.10.0)
+    betterlint (1.10.1)
       rubocop (~> 1.62.0)
       rubocop-performance (~> 1.21.0)
       rubocop-rails (~> 2.24.0)

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.10.0"
+  s.version = "1.10.1"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/lib/rubocop/cop/betterment/redirect_status.rb
+++ b/lib/rubocop/cop/betterment/redirect_status.rb
@@ -17,11 +17,7 @@ module RuboCop
         MSG
 
         def on_def(node)
-          each_offense(node, :redirect_to) do |responder|
-            add_offense(responder) do |corrector|
-              corrector.insert_after(responder.last_argument, ", status: :see_other")
-            end
-          end
+          each_offense(node, :redirect_to) { :see_other }
         end
       end
     end

--- a/lib/rubocop/cop/betterment/redirect_status.rb
+++ b/lib/rubocop/cop/betterment/redirect_status.rb
@@ -19,7 +19,7 @@ module RuboCop
         def on_def(node)
           each_offense(node, :redirect_to) do |responder|
             add_offense(responder) do |corrector|
-              corrector.insert_after(responder, ", status: :see_other")
+              corrector.insert_after(responder.last_argument, ", status: :see_other")
             end
           end
         end

--- a/lib/rubocop/cop/betterment/render_status.rb
+++ b/lib/rubocop/cop/betterment/render_status.rb
@@ -18,15 +18,7 @@ module RuboCop
 
         def on_def(node)
           each_offense(node, :render) do |responder|
-            add_offense(responder) do |corrector|
-              status = infer_status(responder)
-
-              if responder.arguments?
-                corrector.insert_after(responder.last_argument, ", status: #{status.inspect}")
-              else
-                corrector.replace(responder, "render status: #{status.inspect}")
-              end
-            end
+            infer_status(responder)
           end
         end
 

--- a/lib/rubocop/cop/betterment/render_status.rb
+++ b/lib/rubocop/cop/betterment/render_status.rb
@@ -19,19 +19,19 @@ module RuboCop
         def on_def(node)
           each_offense(node, :render) do |responder|
             add_offense(responder) do |corrector|
-              corrector.insert_after(responder, ", status: #{infer_status(responder).inspect}")
+              corrector.insert_after(responder.last_argument, infer_correction(responder))
             end
           end
         end
 
         private
 
-        def infer_status(responder)
+        def infer_correction(responder)
           case extract_template(responder).to_s
             when 'new', 'edit'
-              :unprocessable_entity
+              ", status: :unprocessable_entity"
             else
-              :ok
+              ", status: :ok"
           end
         end
 

--- a/lib/rubocop/cop/betterment/render_status.rb
+++ b/lib/rubocop/cop/betterment/render_status.rb
@@ -19,19 +19,25 @@ module RuboCop
         def on_def(node)
           each_offense(node, :render) do |responder|
             add_offense(responder) do |corrector|
-              corrector.insert_after(responder.last_argument, infer_correction(responder))
+              status = infer_status(responder)
+
+              if responder.arguments?
+                corrector.insert_after(responder.last_argument, ", status: #{status.inspect}")
+              else
+                corrector.replace(responder, "render status: #{status.inspect}")
+              end
             end
           end
         end
 
         private
 
-        def infer_correction(responder)
+        def infer_status(responder)
           case extract_template(responder).to_s
             when 'new', 'edit'
-              ", status: :unprocessable_entity"
+              :unprocessable_entity
             else
-              ", status: :ok"
+              :ok
           end
         end
 

--- a/lib/rubocop/cop/betterment/utils/response_status.rb
+++ b/lib/rubocop/cop/betterment/utils/response_status.rb
@@ -11,9 +11,19 @@ module RuboCop
 
           private
 
-          def each_offense(node, responder_name, &block)
-            if UNSAFE_ACTIONS.include?(node.method_name)
-              on_missing_status(node, responder_name, &block)
+          def each_offense(node, responder_name)
+            return unless UNSAFE_ACTIONS.include?(node.method_name)
+
+            on_missing_status(node, responder_name) do |responder|
+              add_offense(responder) do |corrector|
+                status = yield(responder)
+
+                if responder.arguments?
+                  corrector.insert_after(responder.last_argument, ", status: #{status.inspect}")
+                else
+                  corrector.replace(responder, "#{responder_name} status: #{status.inspect}")
+                end
+              end
             end
           end
 

--- a/lib/rubocop/cop/betterment/utils/response_status.rb
+++ b/lib/rubocop/cop/betterment/utils/response_status.rb
@@ -19,7 +19,10 @@ module RuboCop
 
           # @!method on_missing_status(node)
           def_node_search :on_missing_status, <<~PATTERN
-            (send nil? %1 ... !(hash <(pair (sym :status) _) ...>))
+            {
+              (send nil? %1)
+              (send nil? %1 ... !(hash <(pair (sym :status) _) ...>))
+            }
           PATTERN
         end
       end

--- a/spec/rubocop/cop/betterment/redirect_status_spec.rb
+++ b/spec/rubocop/cop/betterment/redirect_status_spec.rb
@@ -15,6 +15,8 @@ describe RuboCop::Cop::Betterment::RedirectStatus, :config do
       def update
         redirect_to '/'
         ^^^^^^^^^^^^^^^ Did you forget to specify an HTTP status code? [...]
+        redirect_to
+        ^^^^^^^^^^^ Did you forget to specify an HTTP status code? [...]
       end
     RUBY
 
@@ -26,6 +28,7 @@ describe RuboCop::Cop::Betterment::RedirectStatus, :config do
 
       def update
         redirect_to '/', status: :see_other
+        redirect_to status: :see_other
       end
     RUBY
   end
@@ -51,6 +54,7 @@ describe RuboCop::Cop::Betterment::RedirectStatus, :config do
       def create
         redirect_to '/', status: :found
         redirect_to '/', status: :see_other
+        redirect_to status: :found
       end
     RUBY
   end

--- a/spec/rubocop/cop/betterment/redirect_status_spec.rb
+++ b/spec/rubocop/cop/betterment/redirect_status_spec.rb
@@ -8,6 +8,8 @@ describe RuboCop::Cop::Betterment::RedirectStatus, :config do
       def create
         redirect_to '/'
         ^^^^^^^^^^^^^^^ Did you forget to specify an HTTP status code? [...]
+        redirect_to('/')
+        ^^^^^^^^^^^^^^^^ Did you forget to specify an HTTP status code? [...]
       end
 
       def update
@@ -19,6 +21,7 @@ describe RuboCop::Cop::Betterment::RedirectStatus, :config do
     expect_correction(<<~RUBY)
       def create
         redirect_to '/', status: :see_other
+        redirect_to('/', status: :see_other)
       end
 
       def update

--- a/spec/rubocop/cop/betterment/render_status_spec.rb
+++ b/spec/rubocop/cop/betterment/render_status_spec.rb
@@ -72,6 +72,7 @@ describe RuboCop::Cop::Betterment::RenderStatus, :config do
       def create
         render plain: "OK", status: :ok
         render :new, status: :unprocessable_entity
+        render status: :ok
       end
     RUBY
   end

--- a/spec/rubocop/cop/betterment/render_status_spec.rb
+++ b/spec/rubocop/cop/betterment/render_status_spec.rb
@@ -16,6 +16,8 @@ describe RuboCop::Cop::Betterment::RenderStatus, :config do
         ^^^^^^^^^^^^^^ Did you forget to specify an HTTP status code? [...]
         render plain: 'OK'
         ^^^^^^^^^^^^^^^^^^ Did you forget to specify an HTTP status code? [...]
+        render(:new)
+        ^^^^^^^^^^^^ Did you forget to specify an HTTP status code? [...]
       end
 
       def update
@@ -33,6 +35,7 @@ describe RuboCop::Cop::Betterment::RenderStatus, :config do
         render :other, status: :ok
         render 'other', status: :ok
         render plain: 'OK', status: :ok
+        render(:new, status: :unprocessable_entity)
       end
 
       def update

--- a/spec/rubocop/cop/betterment/render_status_spec.rb
+++ b/spec/rubocop/cop/betterment/render_status_spec.rb
@@ -18,6 +18,10 @@ describe RuboCop::Cop::Betterment::RenderStatus, :config do
         ^^^^^^^^^^^^^^^^^^ Did you forget to specify an HTTP status code? [...]
         render(:new)
         ^^^^^^^^^^^^ Did you forget to specify an HTTP status code? [...]
+        render
+        ^^^^^^ Did you forget to specify an HTTP status code? [...]
+        render()
+        ^^^^^^^^ Did you forget to specify an HTTP status code? [...]
       end
 
       def update
@@ -36,6 +40,8 @@ describe RuboCop::Cop::Betterment::RenderStatus, :config do
         render 'other', status: :ok
         render plain: 'OK', status: :ok
         render(:new, status: :unprocessable_entity)
+        render status: :ok
+        render status: :ok
       end
 
       def update


### PR DESCRIPTION
* Handle `render` or `redirect_to` with parentheses
* Handle `render` or `redirect_to` with no arguments
