### PR TITLE
Make Metrics/AbcSize much more liberal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    betterlint (1.11.0)
+    betterlint (1.12.0)
       rubocop (~> 1.62.0)
       rubocop-graphql (~> 1.5.0)
       rubocop-performance (~> 1.21.0)

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.11.0"
+  s.version = "1.12.0"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -143,6 +143,8 @@ Metrics/AbcSize:
   Exclude:
     - spec/**/*
     - webvalve/**/*
+  CountRepeatedAttributes: false
+  Max: 34
 
 Metrics/BlockLength:
   Enabled: false

--- a/lib/rubocop/cop/betterment/authorization_in_controller.rb
+++ b/lib/rubocop/cop/betterment/authorization_in_controller.rb
@@ -51,7 +51,7 @@ module RuboCop
           end
         end
 
-        def on_send(node) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+        def on_send(node) # rubocop:disable Metrics/PerceivedComplexity
           return if !model_new?(node) && !model_update?(node)
 
           node.arguments.each do |argument|
@@ -88,7 +88,7 @@ module RuboCop
 
         # Flags objects being created/updated with unsafe
         # params indirectly from params or through params.permit
-        def flag_indirect_param_use(node) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+        def flag_indirect_param_use(node) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
           name = Utils::Parser.get_root_token(node)
           # extracted_params contains parameters used like:
           # def create

--- a/lib/rubocop/cop/betterment/utils/parser.rb
+++ b/lib/rubocop/cop/betterment/utils/parser.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Betterment
       module Utils
         module Parser
-          def self.get_root_token(node) # rubocop:disable Metrics/PerceivedComplexity, Metrics/AbcSize
+          def self.get_root_token(node) # rubocop:disable Metrics/PerceivedComplexity
             return nil unless node
 
             return get_root_token(node.receiver) if node.receiver
@@ -33,7 +33,7 @@ module RuboCop
             name
           end
 
-          def self.get_return_values(node) # rubocop:disable Metrics/AbcSize
+          def self.get_return_values(node)
             return [] unless node
             return explicit_returns(node) + get_return_values(node.body) if node.def_type?
             return [node] if node.literal? || node.variable?
@@ -84,7 +84,7 @@ module RuboCop
             parameter_names
           end
 
-          def self.get_extracted_parameters(node, param_aliases: []) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+          def self.get_extracted_parameters(node, param_aliases: []) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
             return [] unless node.send_type?
 
             parameter_names = []


### PR DESCRIPTION
The default (17) is pretty restrictive, and sometimes feels inconsistent.

We've seen a few negative consequences of enforcing this AbcSize:

1. People often extract local variables to memoized private methods. This is not desirable, because a local variable actually has a lower cognitive overhead than a memoized, private method.
2. By extracting lots of small, private methods, you're adding more indirection and literally more lines of code to read. Sometimes, this can make it harder to read and understand code.
3. By eagerly extracting lots of small, private methods, you might be making it harder to identify more effective ways of refactoring the code.

We want to lean on code reviewers to raise a concern when code becomes overly complex.

/no-platform