### PR TITLE
feat: disable factory bot association cop by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    betterlint (1.12.0)
+    betterlint (1.13.0)
       rubocop (~> 1.62.0)
       rubocop-graphql (~> 1.5.0)
       rubocop-performance (~> 1.21.0)

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.12.0"
+  s.version = "1.13.0"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -56,6 +56,18 @@ Betterment/NonStandardActions:
     - update
   StyleGuide: '#bettermentnonstandardactions'
 
+Betterment/RedirectStatus:
+  SafeAutoCorrect: false
+  Description: Detect missing status codes when redirecting POST, PUT, PATCH, or DELETE responses
+  Include:
+    - app/controllers/**/*.rb
+
+Betterment/RenderStatus:
+  SafeAutoCorrect: false
+  Description: Detect missing status codes when rendering POST, PUT, PATCH, or DELETE responses
+  Include:
+    - app/controllers/**/*.rb
+
 Betterment/ServerErrorAssertion:
   Description: Detects assertions on 5XX HTTP statuses.
   Include:
@@ -77,17 +89,8 @@ Betterment/UnsafeJob:
 Betterment/UnscopedFind:
   StyleGuide: '#bettermentunscopedfind'
 
-Betterment/RedirectStatus:
-  SafeAutoCorrect: false
-  Description: Detect missing status codes when redirecting POST, PUT, PATCH, or DELETE responses
-  Include:
-    - app/controllers/**/*.rb
-
-Betterment/RenderStatus:
-  SafeAutoCorrect: false
-  Description: Detect missing status codes when rendering POST, PUT, PATCH, or DELETE responses
-  Include:
-    - app/controllers/**/*.rb
+FactoryBot/AssociationStyle:
+  Enabled: false
 
 FactoryBot/ConsistentParenthesesStyle:
   Enabled: false


### PR DESCRIPTION
**Summary of changes**:
Per a conversation in Slack we don't seem to have strong opinions about this, so disabling this cop here for all our projects using Betterlint.
