### PR TITLE
⬆️ rubocop-rspec v3.1.0

### DIFF
--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_dependency "rubocop-performance", "~> 1.21.0"
   s.add_dependency "rubocop-rails", "~> 2.24.0"
   s.add_dependency "rubocop-rake", "~> 0.6.0"
-  s.add_dependency "rubocop-rspec", "~> 2.28.0"
+  s.add_dependency "rubocop-rspec", "~> 3.1.0"
 end


### PR DESCRIPTION
# Replaced by #73 

https://rubygems.org/gems/rubocop-rspec/versions/3.1.0

It is not immediately apparent if there is a legitimate reason to delay the major upgrade from v2 to v3 in `rubocop-rspec`.