### PR TITLE
Fix a couple issues with InternalsProtection cop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    betterlint (1.15.0)
+    betterlint (1.15.1)
       rubocop (~> 1.62.0)
       rubocop-graphql (~> 1.5.0)
       rubocop-performance (~> 1.21.0)

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.15.0"
+  s.version = "1.15.1"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -44,6 +44,11 @@ Betterment/HardcodedID:
   SafeAutoCorrect: false
   StyleGuide: '#bettermenthardcodedid'
 
+Betterment/InternalsProtection:
+  Description: Detects invalid references to Internals modules
+  StyleGuide: '#bettermentinternalsprotection'
+  Enabled: false
+
 Betterment/NonStandardActions:
   AdditionalAllowedActions: []
   Description: Detects non-standard controller actions.

--- a/lib/rubocop/cop/betterment/internals_protection.rb
+++ b/lib/rubocop/cop/betterment/internals_protection.rb
@@ -18,7 +18,7 @@ module RuboCop
 
         # @!method rspec_describe(node)
         def_node_matcher :rspec_describe, <<-PATTERN
-          (block (send (const nil? :RSpec) :describe ${const | str}) ...)
+          (block (send (const nil? :RSpec) :describe ${const | str} ...) ...)
         PATTERN
 
         def on_const(node)

--- a/spec/rubocop/cop/betterment/internals_protection_spec.rb
+++ b/spec/rubocop/cop/betterment/internals_protection_spec.rb
@@ -150,6 +150,14 @@ describe RuboCop::Cop::Betterment::InternalsProtection, :config do
   end
 
   context 'when in a spec with a constant described class' do
+    context 'when subject is within an Internals module' do
+      it 'does not register offences' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo::Internals::Widget, type: :model do
+          end
+        RUBY
+      end
+    end
     context 'when reference is valid' do
       it 'does not register offences' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
/no-platform

This PR fixes two issues with the InternalsProtection cop:
1. The config changes weren't included in the previous PR, making the cop enabled by default.
2. RSpec describe lines with additional parameters were ignored, triggering false positives.
