### PR TITLE
Set enforced shorthand syntax to always

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    betterlint (1.19.0)
+    betterlint (1.20.0)
       rubocop (~> 1.71)
       rubocop-graphql (~> 1.5)
       rubocop-performance (~> 1.23)

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.19.0"
+  s.version = "1.20.0"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -39,7 +39,7 @@ Betterment/DirectDelayedEnqueue:
 
 Betterment/DynamicParams:
   StyleGuide: '#bettermentdynamicparams'
-  
+
 Betterment/EnvironmentConfiguration:
   StyleGuide: '#bettermentenvironmentconfiguration'
   Exclude:
@@ -377,6 +377,9 @@ Style/GuardClause:
 
 Style/IfUnlessModifier:
   Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
 
 Style/Lambda:
   Enabled: false

--- a/spec/standard_compliance_spec.rb
+++ b/spec/standard_compliance_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'standard compliance' do
       Naming/VariableNumber
       Style/BlockDelimiters
       Style/FrozenStringLiteralComment
+      Style/HashSyntax
       Style/LambdaCall
       Style/MissingElse
       Style/NumberedParameters


### PR DESCRIPTION
Rubocop [changed the default](https://github.com/rubocop/rubocop/pull/13300) for `Style/HashSyntax`'s `EnforcedShorthandSyntax` configuration from `always` to `either`.  This reverts that change in `BetterLint` by explicitly setting the value to `either`.

This is not in line with `Standard`'s config, so I added an exception.

I prefer a consistent enforcement style so we don't have any pull-request discussion on whether or not to expand/contract hash syntax. The shorthand syntax also has fewer rooms for typos and makes it more obvious when there are subtle name differences between hash keys and values.