### PR TITLE
feat: increase version to 1.21.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    betterlint (1.20.0)
+    betterlint (1.21.0)
       rubocop (~> 1.71)
       rubocop-graphql (~> 1.5)
       rubocop-performance (~> 1.23)

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.20.0"
+  s.version = "1.21.0"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"


### PR DESCRIPTION
This change increases the version number so we can publish [a recent update](https://github.com/Betterment/betterlint/pull/47) to RubyGems.