### PR TITLE
Disable Rails/SquishedSQLHeredocs cop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    betterlint (1.22.0)
+    betterlint (1.23.0)
       rubocop (~> 1.71)
       rubocop-graphql (~> 1.5)
       rubocop-performance (~> 1.23)

--- a/betterlint.gemspec
+++ b/betterlint.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "betterlint"
-  s.version = "1.22.0"
+  s.version = "1.23.0"
   s.authors = ["Development"]
   s.email = ["development@betterment.com"]
   s.summary = "Betterment rubocop configuration"

--- a/config/default.yml
+++ b/config/default.yml
@@ -364,6 +364,9 @@ Rails/HttpPositionalArguments:
 Rails/OutputSafety:
   Enabled: true
 
+Rails/SquishedSQLHeredocs:
+  Enabled: false
+
 Style/AccessModifierDeclarations:
   Enabled: false
 


### PR DESCRIPTION
We often have to disable this cop because there is syntactically valid whitespace in psql functions and comments. We should disable this by default to avoid potential bugs caused by autocorrecting this cop.